### PR TITLE
Fix startup dependency paths

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,8 +44,8 @@ Three main tables:
 
 ### Backend Setup
 ```bash
-cd backend
 pip install -r requirements.txt
+cd backend
 uvicorn app.main:app --reload --port 8000
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,12 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     
     - name: Install dependencies
       run: |
-        cd backend
         pip install -r requirements.txt
         pip install pytest pytest-cov
     

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -45,9 +45,8 @@ This guide covers the complete deployment process for the Instagram Intelligence
 
 2. Install dependencies:
    ```powershell
-   cd backend
    pip install -r requirements.txt
-   cd ../frontend
+   cd frontend
    npm install
    npm run build
    ```

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies
-COPY backend/requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend code

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -83,6 +83,7 @@
 
 ```
 IGCrawl-Code/
+├── requirements.txt
 ├── backend/
 │   ├── app/
 │   │   ├── api/
@@ -117,7 +118,6 @@ IGCrawl-Code/
 │   │   ├── database.py
 │   │   └── main.py
 │   ├── tests/
-│   └── requirements.txt
 ├── frontend/
 │   ├── src/
 │   ├── package.json

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The application implements Instagram's actual rate limits based on community res
 ## 📁 Project Structure
 
 ```
+├── requirements.txt
 ├── backend/
 │   ├── app/
 │   │   ├── api/          # API endpoints
@@ -88,7 +89,6 @@ The application implements Instagram's actual rate limits based on community res
 │   │   ├── services/     # Business logic
 │   │   ├── utils/        # Utilities (encryption, rate limiting)
 │   │   └── workers/      # Background job handlers
-│   └── requirements.txt
 ├── frontend/
 │   ├── src/
 │   │   ├── components/   # Reusable UI components

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ black==23.12.1
 ruff==0.1.9
 schedule==1.2.0
 Pillow>=8.1.1
+requests>=2.31.0

--- a/scripts/startup.ps1
+++ b/scripts/startup.ps1
@@ -97,12 +97,11 @@ if ($Mode -eq "native") {
     
     # Install Python dependencies
     Write-Host "Installing Python dependencies..." -ForegroundColor Yellow
-    Set-Location backend
-    pip install -r requirements.txt
+    pip install -r "$ProjectRoot\requirements.txt"
     
     # Install frontend dependencies and build
     Write-Host "Building frontend..." -ForegroundColor Yellow
-    Set-Location ../frontend
+    Set-Location frontend
     npm install
     npm run build
     

--- a/scripts/verify_installation.py
+++ b/scripts/verify_installation.py
@@ -8,6 +8,11 @@ import importlib
 import os
 from pathlib import Path
 
+# Ensure project root is on the import path so `backend` can be imported
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 
 def check_python_version():
     """Check Python version is 3.11+"""

--- a/setup.sh
+++ b/setup.sh
@@ -10,9 +10,7 @@ if [[ $python_version < "3.11" ]]; then
 fi
 
 # Install backend requirements
-cd backend
 pip install -r requirements.txt
-cd ..
 
 # Install frontend dependencies
 cd frontend


### PR DESCRIPTION
## Summary
- use root requirements.txt across scripts and docs
- ensure verify_installation.py can import backend
- remove old backend requirements file

## Testing
- `pip install -r ../requirements.txt` *(fails: No route to host)*
- `pytest -q` *(fails: command not found)*